### PR TITLE
Updates to SideNav

### DIFF
--- a/.tina/schema.ts
+++ b/.tina/schema.ts
@@ -19,6 +19,11 @@ export default defineSchema({
           name: "slug",
         },
         {
+          type: "string",
+          label: "Section",
+          name: "section",
+        },
+        {
           type: "rich-text",
           label: "Body",
           name: "body",

--- a/components/SideNav.js
+++ b/components/SideNav.js
@@ -67,7 +67,7 @@ const NavLink = ({ children, href }) => {
   return (
     <Link href={href}>
       {React.cloneElement(child, {
-        "aria-current": trim(router.asPath) === href ? "page" : null
+        "aria-current": trim(router.asPath) === trim(href) ? "page" : null
       })}
     </Link>
   );

--- a/utils/mdxUtils.js
+++ b/utils/mdxUtils.js
@@ -1,17 +1,33 @@
 export const sideMenuItems = (sideNavFiles) => {
+  const files = sideNavFiles?.getDocsList?.edges;
+
+  // If no sideNavFiles, return an empty array
+  if (!files?.length) return [];
+
+  // Create a section-to-children mapping
+  const groupsMapping = {};
+  for (const file of files) {
+    const {title, slug} = file.node.data;
+    let section = file.node.data.section;
+
+    // If no section, use the default one ("Docs")
+    if (!section) section = "Docs";
+
+    if (!groupsMapping[section]) groupsMapping[section] = [];
+    groupsMapping[section].push({
+      slug: slug || "",
+      title: title || "",
+    });
+  }
+
+  // Build the actual menu groups from the previously created mapping
   const menuGroups = [];
-  const group = {};
-  group['section'] = "Docs"
-  group['children'] = []
-  menuGroups.push(group)
-  sideNavFiles?.getDocsList?.edges?.map((file) => {
-    const title = file.node.data.title;
-    const slug = file.node.data.slug;
-      
-      group['children'].push({
-        slug : slug || "", 
-        title: title || "", 
-      })
-  });
-  return menuGroups
-}
+  for (const [section, children] of Object.entries(groupsMapping)) {
+    menuGroups.push({
+      section,
+      children,
+    });
+  }
+
+  return menuGroups;
+};


### PR DESCRIPTION
- Added support for sections in `SideNav`.
- Fix the path string matching for the current page indicator that would not work properly. Now both `href` and `router.asPath` are trimmed before being compared.